### PR TITLE
Add scaffold for Baileys message sending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+clientes.db
+baileys_auth_info/
+__pycache__/

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from telegram.ext import Updater, CommandHandler
 from telegram import Update
 from telegram.ext.callbackcontext import CallbackContext
@@ -13,6 +14,7 @@ class Cliente(Base):
     __tablename__ = "clientes"
     id = Column(Integer, primary_key=True)
     nome = Column(String)
+    telefone = Column(String)
     pacote = Column(String)
 
 Base.metadata.create_all(engine)
@@ -23,15 +25,16 @@ def start(update: Update, context: CallbackContext):
     update.message.reply_text("Bem-vindo! Use /addcliente e /listarclientes.")
 
 def add_cliente(update: Update, context: CallbackContext):
-    """Uso: /addcliente Nome Pacote"""
+    """Uso: /addcliente Nome Telefone Pacote"""
     session = Session()
-    if len(context.args) < 2:
-        update.message.reply_text("Uso: /addcliente Nome Pacote")
+    if len(context.args) < 3:
+        update.message.reply_text("Uso: /addcliente Nome Telefone Pacote")
         return
 
     nome = context.args[0]
-    pacote = " ".join(context.args[1:])
-    cliente = Cliente(nome=nome, pacote=pacote)
+    telefone = context.args[1]
+    pacote = " ".join(context.args[2:])
+    cliente = Cliente(nome=nome, telefone=telefone, pacote=pacote)
     session.add(cliente)
     session.commit()
     update.message.reply_text(f"Cliente {nome} adicionado com pacote {pacote}.")
@@ -43,8 +46,25 @@ def listar_clientes(update: Update, context: CallbackContext):
         update.message.reply_text("Nenhum cliente cadastrado.")
         return
 
-    resposta = "\n".join(f"{c.id} - {c.nome} ({c.pacote})" for c in clientes)
+    resposta = "\n".join(
+        f"{c.id} - {c.nome} {c.telefone} ({c.pacote})" for c in clientes
+    )
     update.message.reply_text(resposta)
+
+
+def enviar(update: Update, context: CallbackContext):
+    """Uso: /enviar ID Mensagem"""
+    if len(context.args) < 2:
+        update.message.reply_text("Uso: /enviar ID Mensagem")
+        return
+    session = Session()
+    cliente = session.get(Cliente, int(context.args[0]))
+    if not cliente:
+        update.message.reply_text("Cliente não encontrado.")
+        return
+    mensagem = " ".join(context.args[1:])
+    subprocess.run(["node", "whatsapp.js", cliente.telefone, mensagem])
+    update.message.reply_text(f"Mensagem enviada para {cliente.nome}.")
 
 def main():
     token = os.getenv("TELEGRAM_BOT_TOKEN")
@@ -54,6 +74,7 @@ def main():
     dp.add_handler(CommandHandler("start", start))
     dp.add_handler(CommandHandler("addcliente", add_cliente))
     dp.add_handler(CommandHandler("listarclientes", listar_clientes))
+    dp.add_handler(CommandHandler("enviar", enviar))
 
     updater.start_polling()
     updater.idle()

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gestor2025",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node whatsapp.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@whiskeysockets/baileys": "^6.7.0"
+  }
+}

--- a/whatsapp.js
+++ b/whatsapp.js
@@ -1,0 +1,21 @@
+const { default: makeWASocket, useMultiFileAuthState } = require('@whiskeysockets/baileys');
+
+async function sendMessage(number, message) {
+  const { state, saveCreds } = await useMultiFileAuthState('baileys_auth_info');
+  const sock = makeWASocket({ auth: state });
+  sock.ev.on('creds.update', saveCreds);
+  await sock.waitForConnectionUpdate && sock.waitForConnectionUpdate();
+  await sock.sendMessage(`${number}@s.whatsapp.net`, { text: message });
+  sock.end();
+}
+
+const [,, number, ...msgParts] = process.argv;
+if (!number || msgParts.length === 0) {
+  console.log('Usage: node whatsapp.js <number> <message>');
+  process.exit(1);
+}
+
+sendMessage(number, msgParts.join(' ')).catch(err => {
+  console.error('Error sending message', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- extend Telegram bot to store client phone numbers and invoke a Node script to send WhatsApp messages
- add `whatsapp.js` example using Baileys and npm config
- ignore generated files and databases

## Testing
- `python -m py_compile bot.py`
- `node whatsapp.js` *(fails: Cannot find module '@whiskeysockets/baileys')*
- `npm install @whiskeysockets/baileys` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a76413210c832aae17b1e0205675c4